### PR TITLE
Update Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -56,7 +56,7 @@ class Client
      *
      * @throws EboekhoudenSoapException
      */
-    protected function createSoapClient(): void
+    protected function createSoapClient()
     {
         if (! empty($this->soapClient) && ! empty($this->sessionId)) {
             return;


### PR DESCRIPTION
Removed :void as returning reference.
At line 59
This is deprecated as of PHP 8.1.0
https://www.php.net/manual/en/language.types.declarations.php